### PR TITLE
Typo in usage example

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -87,8 +87,8 @@ export default {
             fields: [
               {
                 type: 'select',
-                label: 'skills',
-                model: 'type',
+                label: 'Skills',
+                model: 'skills',
                 values: ['Javascript', 'VueJS', 'CSS3', 'HTML5']
               },
               {


### PR DESCRIPTION
Capitalise label property for consistency, and change model property (If I have understood the documentation correctly)