### PR TITLE
fix typo in property name

### DIFF
--- a/component/options.md
+++ b/component/options.md
@@ -9,6 +9,6 @@ validateAfterLoad      | `false`    | `boolean`   | Execute validation after mod
 validateAfterChanged   | `false`    | `boolean`   | Execute validation after every change
 fieldIdPrefix          | _none_     | `string`    | Prefix to add to every field's `id`. Will be prepended to ids explicity set in the schema, as well as auto-generated ones.
 validateAsync          | `false`    | `boolean`   | `validate()` method returns a Promise, refer to [validation](/validation/custom-validators.md#asynchronous-validators)
-validationErrorCLass   | `"error"`  | `string`    | CSS Class attached to elements which are invalid
+validationErrorClass   | `"error"`  | `string`    | CSS Class attached to elements which are invalid
 validationSuccessClass | _none_     | `string`    | CSS Class attached to elements which are valid
 validateDebounceTime   | `0`        | `integer`   | Amount of time in milliseconds validation waits before checking, refer to [validation](/validation/README.md#debounce)


### PR DESCRIPTION
validationErrorClass had an uppercase `L` which was not correct when I tried to copy and paste